### PR TITLE
add glob support for excluding files and dirs

### DIFF
--- a/src/http/server.clj
+++ b/src/http/server.clj
@@ -218,11 +218,13 @@
      :body body}))
 
 (defn matches-glob? [file glob]
-  (.matches
-   (.getPathMatcher
-    (java.nio.file.FileSystems/getDefault)
-    (str "glob:" "**/nasus/"  glob))
-   (.toPath file)))
+  (let [cwd (System/getProperty "user.dir")
+        glob (str cwd "/" glob)]
+    (.matches
+     (.getPathMatcher
+      (java.nio.file.FileSystems/getDefault)
+      (str "glob:" glob))
+     (.toPath file))))
 
 ;; note, that mime types and cache headers will be
 ;; injected by appropriate middlewares later on
@@ -384,7 +386,12 @@
    ["-b" "--bind <IP>" "Address to bind to"
     :default default-bind]
    [nil "--auth <USER[:PASSWORD]>" "Basic auth"]
-   [nil "--exclude <GLOB>" "Exclude certain file-paths"]
+   [nil "--exclude <GLOB>" (str "Exclude certain file-paths specified by either "
+                                "a single glob, or whitespace delimited series of globs:\n"
+                                "\"target/*\"  -> direct descendants of target\n"
+                                "\"target/**\" -> all descendants of target\n"
+                                "\"target/* **.txt\" -> direct descendants of target "
+                                "and all .txt files")]
    [nil "--no-index" "Disable directory listings" :default false]
    [nil "--no-cache" "Disable cache headers" :default false]
    [nil "--no-compression" "Disable deflate and gzip compression" :default false]


### PR DESCRIPTION
This addresses issue #8 

I  added glob support to exclude files/paths for any glob passed to the CLI, which seemed easier than trying to limit it to a subset as mentioned in the issue.  If limiting, I wasn't sure if I should try to somehow restrict globs by checking first, or just use regex, etc.  This seemed the path of least resistance and also has the nice by-product of being more flexible anyways.

I wasn't sure if you wanted to 404 or 403 for restricted dirs, I put 404 for now.