### PR TITLE
Add option to choose directory to serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ In development:
 ```
   -p, --port <PORT>         8000     Port number
   -b, --bind <IP>           0.0.0.0  Address to bind to
+      --dir <PATH>          ./       Directory to serve files
       --auth <USER[:PASSWORD]>       Basic auth
       --no-index                     Disable directory listings
       --no-cache                     Disable cache headers

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nasus "0.1.5"
+(defproject nasus "0.1.6"
   :description "A simple zero-configuration command-line HTTP files server that scales"
   :url "https://github.com/kachayev/nasus"
   :license {:name "MIT License"


### PR DESCRIPTION
This can be useful for example when serving a project`s "resources/public" while using deps.edn, such as:

```edn
{:aliases 
	{:serve {:extra-deps {nasus {:mvn/version "0.1.6"}}
                     :main-opts ["-m" "http.server"
                                 "--dir" "resources/public"]}}}
```