### PR TITLE
Fix If-Modified-Since handling

### DIFF
--- a/src/http/server.clj
+++ b/src/http/server.clj
@@ -107,7 +107,7 @@
 
 (defn parse-if-modified-header [value]
   (let [formatter (http-date-formatter)]
-    (/ (.getTime (.parse formatter value)) 1000.0)))
+    (quot (.getTime (.parse formatter value)) 1000)))
 
 (defn inject-cache-headers [{:keys [body] :as response}]
   (let [last-modified (.lastModified ^File body)
@@ -123,10 +123,10 @@
     (if (str/blank? header)
       (inject-cache-headers response)
       (let [if-modified (parse-if-modified-header header)
-            file-modified (/ (.lastModified ^File body) 1000.0)]
+            file-modified (quot (.lastModified ^File body) 1000)]
         (if (< if-modified file-modified)
-          not-modified
-          (inject-cache-headers response))))))
+          (inject-cache-headers response)
+          not-modified)))))
 
 (defn wrap-if-modified [no-cache? handler]
   (if (true? no-cache?)


### PR DESCRIPTION
There appeared to be two issues:

1. The if/else branch was inverted.
2. The granularity was too fine, which meant that using the returned
   Last-Modified header, even with (1) fixed, got a 200 response.

It's possible to test manually just by updating a file and checking what
Nasus returns. I wrote a test script that checks the behavior too. (It
assumes a web server already running, listening on port 8000.) See
https://gist.github.com/dandorman/5a70353a0f6902e721f127bf0786f9db