### PR TITLE
Update to safe log4j2/SLF4J2 version?

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,12 @@
+{:deps
+ {org.clojure/clojure {:mvn/version "1.10.0"}
+  org.clojure/tools.cli {:mvn/version "0.4.1"}
+  org.slf4j/slf4j-log4j12 {:mvn/version "1.7.32"}
+  org.apache.logging.log4j/log4j-core
+  {:mvn/version "2.17.0"
+   :exclusions [javax.mail/mail
+                javax.jms/jms
+                com.sun.jmdk/jmxtools
+                com.sun.jmx/jmxri]}
+  aleph/aleph {:mvn/version "0.4.7-alpha5"}
+  org.apache.tika/tika-core {:mvn/version "1.20"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps
  {org.clojure/clojure {:mvn/version "1.10.0"}
   org.clojure/tools.cli {:mvn/version "0.4.1"}
-  org.slf4j/slf4j-log4j12 {:mvn/version "1.7.32"}
+  org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.17.0"}
   org.apache.logging.log4j/log4j-core
   {:mvn/version "2.17.0"
    :exclusions [javax.mail/mail

--- a/project.clj
+++ b/project.clj
@@ -5,11 +5,12 @@
             :url "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/tools.cli "0.4.1"]
-                 [org.slf4j/slf4j-log4j12 "1.7.26"]
-                 [log4j/log4j "1.2.17" :exclusions [javax.mail/mail
-                                                    javax.jms/jms
-                                                    com.sun.jmdk/jmxtools
-                                                    com.sun.jmx/jmxri]]
+                 [org.slf4j/slf4j-log4j12 "1.7.32"]
+                 [org.apache.logging.log4j/log4j-core "2.17.0"
+                  :exclusions [javax.mail/mail
+                               javax.jms/jms
+                               com.sun.jmdk/jmxtools
+                               com.sun.jmx/jmxri]]
                  [aleph "0.4.7-alpha5"]
                  [org.apache.tika/tika-core "1.20"]]
   :main http.server

--- a/project.clj
+++ b/project.clj
@@ -3,17 +3,11 @@
   :url "https://github.com/kachayev/nasus"
   :license {:name "MIT License"
             :url "https://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.10.0"]
-                 [org.clojure/tools.cli "0.4.1"]
-                 [org.slf4j/slf4j-log4j12 "1.7.32"]
-                 [org.apache.logging.log4j/log4j-core "2.17.0"
-                  :exclusions [javax.mail/mail
-                               javax.jms/jms
-                               com.sun.jmdk/jmxtools
-                               com.sun.jmx/jmxri]]
-                 [aleph "0.4.7-alpha5"]
-                 [org.apache.tika/tika-core "1.20"]]
+  :dependencies []
   :main http.server
+  :plugins [[lein-tools-deps "0.4.5"]]
+  :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
+  :lein-tools-deps/config {:config-files [:install :user :project]}
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}}
   :deploy-repositories [["clojars" {:sign-releases false}]])

--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -1,8 +1,0 @@
-log4j.rootLogger=INFO, console
-
-# log to the console
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.Target=System.out
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{[MM/dd/YYYY HH:mm:ss]} \u001b[1m%c{2}\u001b[0m :: %m%n
-

--- a/resources/log4j2.properties
+++ b/resources/log4j2.properties
@@ -1,0 +1,13 @@
+# log4j.rootLogger=INFO, console
+rootLogger.level = INFO
+
+# log to the console
+# log4j.appender.console=org.apache.log4j.ConsoleAppender
+appender.console.type = Console
+rootLogger.appenderRef.stdout.ref = STDOUT
+# log4j.appender.console.Target=System.out
+appender.console.name = STDOUT
+# log4j.appender.console.layout=org.apache.log4j.PatternLayout
+appender.console.layout.type = PatternLayout
+# log4j.appender.console.layout.ConversionPattern=%d{[MM/dd/YYYY HH:mm:ss]} \u001b[1m%c{2}\u001b[0m :: %m%n
+appender.console.layout.pattern = %d{[MM/dd/yyyy HH:mm:ss]} \u001b[1m%c{2}\u001b[0m :: %m%n


### PR DESCRIPTION
Hello, @kachayev  -

Thanks for writing `nasus`. It's really nice to be able to add an optional HTTP static file server to basically any project with a single `deps.edn` alias for it.

With all the buzz around CVE-2021-44228, I was doing an audit of some of my projects' dependencies and I did notice that `nasus` uses log4j. 

As I note in one of my commit messages, this appears not to be a safety-critical upgrade for `nasus`; the 1.x branch of log4j contained no vulnerability to CVE-2021-44228, and CVE-2021-4104 only applies to applications using log4j 1.x versions with JMSAppender enabled (which it wasn't here), so there is no evidence that any `nasus` HTTP servers were affected by these vulnerabilities.

Nevertheless, I took it as an opportunity to update to the current safest version of log4j2, as log4j 1.x has reached end of life. I informally verified that the logging configuration continues to have the expected behavior after updating the properties file to the log4j2 format, and the test suite passes.

If you'd prefer not to merge this PR, that's fine too. But I figured I would at least offer it up as a way of giving back to a project that's been pretty useful to me over the past couple of years. Happy also to incorporate any feedback you may have.